### PR TITLE
feat: Add GitHub Release workflow and ignore dist/ folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,11 @@ jobs:
 
       - name: Run ESLint
         run: npm run eslint
+
+      - name: Release
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+          tag_name: latest
+          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 log/
 node_modules/
+dist/


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automatically create a release on every push to the `main` branch. The `dist/` folder, containing the bundled application, will be uploaded as a release asset with the tag `latest`. This allows for easy access to the latest build artifacts without versioning the `dist/` folder in the repository.

Additionally, the `dist/` folder has been added to `.gitignore` to prevent it from being tracked by Git.