### PR TITLE
feat: Add GitHub Release workflow (v2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build the application
         run: npm run build
 
+      - name: Create archive
+        run: tar -czf dist.tar.gz dist
+
       - name: Run ESLint
         run: npm run eslint
 
@@ -35,6 +38,6 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v1
         with:
-          files: dist/*
+          files: dist.tar.gz
           tag_name: latest
           overwrite: true


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automatically create a release on every push to the `main` branch. The `dist/` folder is archived into a `dist.tar.gz` and uploaded as a release asset with the tag `latest`. This allows for easy access to the latest build artifacts without versioning the `dist/` folder in the repository.