### PR TITLE
Create interactive installation using an LVM with two disks

### DIFF
--- a/src/checks/storage_select_installation_device.ts
+++ b/src/checks/storage_select_installation_device.ts
@@ -1,11 +1,12 @@
-import { it, page } from "../lib/helpers";
+import { it, page, waitUntilOverlaySettled } from "../lib/helpers";
+import { getElementByLabel } from "../lib/form";
 import { SidebarPage } from "../pages/sidebar_page";
 import { ConfigureLvmVolumeGroupPage } from "../pages/configure_lvm_volume_group_page";
 import { StorageSettingsPage } from "../pages/storage_settings_page";
 import { OverviewPage } from "../pages/overview_page";
 import { HeaderPage } from "../pages/header_page";
 
-export function selectMoreDevices() {
+export function addLVMVolumeGroup(disks?: string[]) {
   it("should add LVM volume group", async function () {
     const storage = new StorageSettingsPage(page);
     const lvm = new ConfigureLvmVolumeGroupPage(page);
@@ -15,13 +16,15 @@ export function selectMoreDevices() {
     await overview.goToStorage();
     await storage.selectMoreDevices();
     await storage.addLvmVolumeGroup();
-    await lvm.accept();
+    if (disks)
+      for (const disk of disks)
+        await (await getElementByLabel(page, lvm.diskCheckboxSelector, disk)).click();
+    await waitUntilOverlaySettled(() => lvm.accept());
     await header.goToInstallation();
-    await overview.ensureSystemInformationPresent();
   });
 }
 
-export function selectMoreDevicesWithSidebar() {
+export function addLVMVolumeGroupWithSidebar() {
   it("should add LVM volume group", async function () {
     const storage = new StorageSettingsPage(page);
     const lvm = new ConfigureLvmVolumeGroupPage(page);

--- a/src/lib/form.ts
+++ b/src/lib/form.ts
@@ -1,0 +1,29 @@
+import { type ElementHandle, type Page } from "puppeteer-core";
+
+/**
+ * Finds an element whose associated <label> text contains `label`, then clicks it.
+ *
+ * @param page - Puppeteer Page instance
+ * @param label - Text to match inside the element's associated label
+ * @param selector - Target selector (e.g., '::-p-aria([role="checkbox"])')
+ */
+export async function getElementByLabel(
+  page: Page,
+  selector: string,
+  label: string
+): Promise<ElementHandle<HTMLElement>> {
+  const elements = await page.$$(selector);
+
+  for (const element of elements) {
+    const text = await element.evaluate(
+      (e) => (e as HTMLInputElement).labels?.[0]?.textContent ?? ""
+    );
+    if (text.includes(label)) {
+      return element as ElementHandle<HTMLElement>;
+    }
+  }
+
+  throw new Error(
+    `Element with selector "${selector}" and label "${label}" not found`
+  );
+}

--- a/src/lib/product_strategy_factory.ts
+++ b/src/lib/product_strategy_factory.ts
@@ -26,7 +26,7 @@ export interface IProductTestStrategy {
   changePatterns(patterns: string[]): void;
   selectDesktop?(desktop: string): void;
   changeFileSystemToBtrfsWithoutSnapshotsAndAdjustToMinSize(): void;
-  selectMoreDevices(): void;
+  configureVolumeGroup(disks?: string[]): void;
   setOnlyInstallationNetwork(): void;
   verifyDecryptDestructiveActions(destructiveActions: string[]): void;
   verifyStorageOutOfSync?(): void;

--- a/src/pages/configure_lvm_volume_group_page.ts
+++ b/src/pages/configure_lvm_volume_group_page.ts
@@ -3,9 +3,12 @@ import { type Page } from "puppeteer-core";
 export class ConfigureLvmVolumeGroupPage {
   private readonly page: Page;
   private readonly acceptButton = () => this.page.locator("button::-p-text(Accept)");
-
   constructor(page: Page) {
     this.page = page;
+  }
+
+  get diskCheckboxSelector(): string {
+    return '::-p-aria([role="checkbox"])';
   }
 
   async accept() {

--- a/src/test_lvm.ts
+++ b/src/test_lvm.ts
@@ -1,4 +1,4 @@
-import { parse } from "./lib/cmdline";
+import { parse, commaSeparatedList } from "./lib/cmdline";
 import { test_init } from "./lib/helpers";
 import { Option } from "commander";
 
@@ -11,6 +11,11 @@ const options = parse((cmd) =>
     .option(
       "--connections-only-for-installation",
       "The connections will be used only during installation",
+    )
+    .option(
+      "--lvm-additional-disks <disk-name>",
+      "Specify a list of additional disks to configure the volume group, without /dev/ prefix (e.g., vdb)",
+      commaSeparatedList,
     )
     .addOption(
       new Option(
@@ -29,7 +34,7 @@ const testStrategy = ProductStrategyFactory.create(
 
 logIn(options.password);
 if (options.prepareAdvancedStorage === "dasd") testStrategy.prepareDasdStorage();
-testStrategy.selectMoreDevices();
+testStrategy.configureVolumeGroup(options.lvmAdditionalDisks);
 if (options.connectionsOnlyForInstallation) testStrategy.setOnlyInstallationNetwork();
 if (options.install) {
   testStrategy.performInstallation();

--- a/src/test_lvm_encrypted.ts
+++ b/src/test_lvm_encrypted.ts
@@ -16,7 +16,7 @@ const testStrategy = ProductStrategyFactory.create(
 );
 
 logIn(options.password);
-testStrategy.selectMoreDevices();
+testStrategy.configureVolumeGroup();
 testStrategy.enableEncryption(options.password);
 if (options.install) {
   testStrategy.performInstallation();

--- a/src/variants/maintenance_release_strategy.ts
+++ b/src/variants/maintenance_release_strategy.ts
@@ -28,7 +28,7 @@ import { prepareZfcpStorageWithSidebar } from "../checks/storage_zfcp";
 import { selectPatternsWithSidebar } from "../checks/software";
 import { changeFileSystemToBtrfsWithoutSnapshotsAndAdjustToMinSizeWithSidebar } from "../checks/storage_change_root_partition";
 import { ensureLandingOnOverviewWithSidebar } from "../checks/overview";
-import { selectMoreDevicesWithSidebar } from "../checks/storage_select_installation_device";
+import { addLVMVolumeGroupWithSidebar } from "../checks/storage_select_installation_device";
 import { setOnlyInstallationNetworkWithSidebar } from "../checks/network";
 import { verifyDecryptDestructiveActionsWithSidebar } from "../checks/storage_result_destructive_actions_planned";
 import { verifyStorageOutOfSyncWithSidebar } from "../checks/storage_out_of_sync";
@@ -115,8 +115,8 @@ export class MaintenanceReleaseStrategy implements IProductTestStrategy {
     changeFileSystemToBtrfsWithoutSnapshotsAndAdjustToMinSizeWithSidebar();
   }
 
-  selectMoreDevices() {
-    selectMoreDevicesWithSidebar();
+  configureVolumeGroup() {
+    addLVMVolumeGroupWithSidebar();
   }
 
   setOnlyInstallationNetwork() {

--- a/src/variants/production_release_strategy.ts
+++ b/src/variants/production_release_strategy.ts
@@ -25,7 +25,7 @@ import {
 import { changeFileSystemToBtrfsWithoutSnapshotsAndAdjustToMinSize } from "../checks/storage_change_root_partition";
 import { prepareZfcpStorage } from "../checks/storage_zfcp";
 import { ensureLandingOnOverview } from "../checks/overview";
-import { selectMoreDevices } from "../checks/storage_select_installation_device";
+import { addLVMVolumeGroup } from "../checks/storage_select_installation_device";
 import { setOnlyInstallationNetwork } from "../checks/network";
 import { verifyDecryptDestructiveActions } from "../checks/storage_result_destructive_actions_planned";
 import { verifyStorageOutOfSync } from "../checks/storage_out_of_sync";
@@ -119,8 +119,8 @@ export class ProductionReleaseStrategy implements IProductTestStrategy {
     changeFileSystemToBtrfsWithoutSnapshotsAndAdjustToMinSize();
   }
 
-  selectMoreDevices() {
-    selectMoreDevices();
+  configureVolumeGroup(disks?: string[]) {
+    addLVMVolumeGroup(disks);
   }
 
   setOnlyInstallationNetwork() {


### PR DESCRIPTION
##
### Create interactive installation using an LVM with two disks
- Related ticket:
  - https://progress.opensuse.org/issues/203949
- Related MR:
  - https://gitlab.suse.de/qe-yam/openqa-job-groups/-/merge_requests/886
- VR:
  - [__sles_lvm_2_disks__](https://openqa.suse.de/tests/overview?version=16.1&build=hjluo_sles_lvm_999&distri=sle)

##