### PR TITLE
Add project instructions and Claude Code skills

### DIFF
--- a/.claude/skills/agama-test/SKILL.md
+++ b/.claude/skills/agama-test/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: agama-test
+description: >
+  Create a new Agama integration test or modify an existing one from a description, then validate
+  it against a live Agama instance. Use when asked to add, update, or fix an integration test,
+  adapt a test or page object to an Agama UI change, or add a new check or page object.
+---
+
+# Authoring an Agama integration test
+
+Follow the phases in order. Pass the static gate before the live run.
+
+## Phase 1 — Pristine branch
+
+```bash
+git fetch upstream
+git switch -c <kebab-slug> upstream/main
+```
+
+If the working tree has uncommitted changes to tracked files, stop and ask what to do with them.
+Never `git clean` — it destroys work outside the tracked set.
+
+## Phase 2 — Classify the change
+
+Decide the shape before writing anything. This determines the file set, and getting it wrong is
+the most common failure — wiring four of five places leaves a half-broken strategy.
+
+| Question | Files to touch |
+|---|---|
+| A whole new scenario? | New `src/test_*.ts` only. Webpack auto-discovers every `src/test_*.ts` as an entry; there is nothing to register. |
+| A new step inside an existing flow? | New page object in `src/pages/` + new check in `src/checks/` + new method on `IProductTestStrategy` (`src/lib/product_strategy_factory.ts`) + an implementation in each `src/variants/` file the step applies to. |
+| A UI change affecting one release only? | New check variant + override in the affected strategy only. `DevelopmentReleaseStrategy extends ProductionReleaseStrategy`, so overriding there leaves production untouched. |
+
+Entry points (`src/test_*.ts`) are scripts, not suites: they call `test_init(options)`, build a
+strategy via `ProductStrategyFactory.create(...)`, then call check functions that register `it()`
+blocks.
+
+**If the entry point builds a strategy, every step it sequences goes through that strategy** —
+even one that behaves identically on every release. Import the check into the variant, not into
+the entry point. Only steps that run before the strategy exists (`logIn`, `productSelection`) are
+called directly.
+
+**Implement only the releases you were asked about.** Mark the interface method optional, add it
+to the strategies it applies to, and call it as `testStrategy.changeAppearance?.()` so the others
+skip it — the `verifyStorageOutOfSync?` / `src/test_phub.ts` pair is the precedent. Leaving 16.0
+unimplemented beats guessing at a sidebar locator nobody verified.
+
+## Phase 3 — Discover real selectors, in Firefox
+
+**Firefox is the only browser we support.** `src/lib/helpers.ts` launches with
+`protocol: "webDriverBiDi"` and `firefox` is the default in `src/lib/cmdline.ts`; the Live ISO and
+openQA run Firefox, so a Firefox run is what proves a selector.
+
+A live Agama instance is normally reachable. Use it, and read every accessible name off a real
+run: the browser computes them from the rendered accessibility tree, so a name guessed from the
+markup frequently does not match. Firefox also folds adjacent text together — the assertions on
+strings such as `"Danger alert:Could not log in"` in `src/checks/login.ts` are what it produces.
+
+Discover them with a throwaway script under `log/`:
+
+```js
+// log/inspect.mjs — node log/inspect.mjs
+import * as puppeteer from "puppeteer-core";
+
+const browser = await puppeteer.launch({
+  protocol: "webDriverBiDi",
+  browser: "firefox",
+  executablePath: "/usr/bin/firefox",
+  headless: true,
+  acceptInsecureCerts: true,
+  defaultViewport: { width: 1280, height: 800 },
+});
+const page = await browser.newPage();
+await page.goto("https://agama.local", { waitUntil: "domcontentloaded" });
+await page.locator("input#password").fill("nots3cr3t");
+await page.locator("button[type='submit']").click();
+// ...navigate to the screen under test, then dump candidates:
+console.log(
+  await page.evaluate(() =>
+    [...document.querySelectorAll("a, button, input, select, textarea, [role], [aria-label]")]
+      .filter((el) => el.getClientRects().length)
+      .map((el) => ({
+        tag: el.tagName.toLowerCase(),
+        role: el.getAttribute("role"),
+        ariaLabel: el.getAttribute("aria-label"),
+        text: (el.innerText || "").replace(/\s+/g, " ").trim().slice(0, 80),
+        id: el.id,
+      })),
+  ),
+);
+await browser.close();
+```
+
+This reads the DOM because `page.accessibility.snapshot()`, `page.createCDPSession()` and
+`page.client()` are unavailable under WebDriver BiDi — take anything you need from the a11y layer
+via `page.evaluate` and ARIA attributes.
+
+Capture the **role as well as the name** for every element you intend to target; the locators
+written in Phase 4 need both.
+
+Then **confirm** each candidate actually resolves in Firefox before committing to it, e.g.
+`await page.locator('::-p-aria([name="Install"][role="button"])').wait()`. A locator counts as
+proven once a Firefox run matches it.
+
+## Phase 4 — Write to the repo's conventions
+
+**Write the simplest thing that covers the request.** This is the rule that gets broken most
+often. The team writes plain TypeScript and a page object is scaffolding, not a framework — plain,
+obvious, slightly repetitive code is the target, and a reviewer should understand a new check in
+one pass.
+
+- **Build exactly the case you were asked for**, as one straight sequence of calls. "I plan to add
+  more of these later" is context, not a request for an extension mechanism: hard-code the
+  scenario and skip lookup tables of settings, case arrays and all-optional options objects. Every
+  check registers at least one `it()`. A second real caller is what justifies generalising, and
+  doing it then is a cheap edit.
+- **Plain types only**: `string`, `boolean`, `string[]`, plain `interface`s. Avoid
+  `keyof`, mapped and indexed types, generics and `as` casts. The `GConstructor` mixin is the one
+  exception, and only where it already exists.
+- **Prefer one named locator per element**, with the accessible name written out as a literal so
+  grep finds it when the UI renames the control. Interpolating the name suits a genuinely open set
+  — a row per device, a button per product id, as `productId()` and `productModeButton()` do — but
+  on a first iteration writing the handful out is clearer, and collapsing them later is a smaller
+  change than untangling a clever locator.
+- **Literal test titles**, never assembled from variables — the title is what a failing openQA job
+  shows.
+- **Assert literal expected values.** Write the expectation as a constant rather than computing it
+  at runtime. A setting left on an automatic or environment-following default resolves differently
+  per machine — desktop theme, locale, screen size, a local browser versus a virtual machine
+  viewer — so pick the scenario whose expected result is a constant everywhere.
+- **No comments narrating the code.** If a step needs a sentence to say what it does, simplify the
+  step. Reserve comments for genuinely surprising UI behaviour.
+
+**Selectors.** Follow the ARIA name-and-role convention in CLAUDE.md ("Always identify elements by
+ARIA name *and* role"), including its fallback order. Take the role for each locator from the
+Phase 3 dump, and keep CSS engine-neutral: `::-webkit-*` and other vendor-prefixed pseudo-elements
+silently fail in Firefox, while Puppeteer's `::-p-text()` / `::-p-aria()` are fine.
+
+**Page objects, checks, shared helpers, `*WithSidebar` naming and ts-prune all follow CLAUDE.md.**
+Two things it does not cover:
+
+- `src/pages/system_page.ts` with `setStaticHostname` in `src/checks/system.ts` is a small
+  end-to-end pair to copy the shape from: one named ARIA locator per element, one action method
+  per interaction, and a check that reads top to bottom.
+- **Reuse before adding** — read the helpers in `src/lib/helpers.ts` and `src/lib/table.ts` before
+  writing a new one.
+
+## Phase 5 — Static gate
+
+```bash
+npm run build   # this IS the typecheck and the lint gate
+npm run prune   # fails on unused exports
+```
+
+Both must pass before going near the live instance. Use `ESLINT=0` for quick intermediate checks
+only; the final gate runs lint. `npm run devel` gates identically and is faster, so it suits
+iteration — but what gets committed is the `build` output, as CLAUDE.md and `ship-pr` cover.
+
+## Phase 6 — Live run and iterate
+
+```bash
+./dist/test_<name>.js -u <url> --product-version <v> --agama-web-ui-package-version <v>
+```
+
+Both version flags are **mandatory**: `ProductStrategyFactory.create()` does
+`agamaWebUiPackageVersion.split("+")[1].split(".")` unguarded and throws a bare `TypeError` if the
+value is missing or has no `+` (e.g. `21+155.abc`). Supported combinations are `16.0`, and `16.1`
+with a web UI version — see the factory for the exact thresholds.
+
+The browser defaults to Firefox; leave `-b` off. Only a Firefox run counts as validation.
+
+Run headless; `-h` (headed) and `-d <ms>` (slow-mo) are for humans watching. Add `-c` only when
+you deliberately want the run to continue past a failure.
+
+On failure the wrapped `it()` writes `log/<label>.png`, `log/<label>.html` and `log/index.css`.
+**Read the screenshot** — it is directly viewable and usually shows the problem immediately. Then
+fix, rebuild, rerun.
+
+Loop until the run is green or you are genuinely blocked. Report which steps passed, which failed,
+and which never ran.
+
+When it is green, hand off to the `ship-pr` skill.

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ship-pr
+description: >
+  Rebuild dist, squash the branch into a single commit, push, and open or update a pull request
+  against upstream. Use when validated changes are ready to ship.
+---
+
+# Shipping a change
+
+This repo commits its build output, and works one squashed commit per PR. Both are easy to get
+wrong; follow the steps in order.
+
+## 1. Rebuild — mandatory
+
+```bash
+npm run build
+```
+
+`dist/` is **tracked**. A commit whose `dist/` does not match `src/` ships stale
+bundles to the Live ISO. This repo already carries several commits that exist only to repair that
+mistake (`1403213`, `5025016`, `eecbb7b`). Never skip this step, even for a one-line source
+change, and never use `ESLINT=0` here.
+
+Use `build`, not `devel` — what gets committed is the production output; `devel` is for iterating.
+Production mode also emits `dist/vendor.js.LICENSE.txt`, which belongs in the commit. The bundles
+currently in git were built with `devel`, so the first `build` commit rewrites every tracked file
+in `dist/`; that one-off churn is expected, and after it a `devel` bundle committed over a
+production one would show up as the whole file changing.
+
+One diff is expected noise: webpack bakes an absolute path into the yargs ESM shim in
+`dist/vendor.js`, so a rebuild always rewrites that line to your own home directory. If it is the
+only `dist/` change, revert it — `git checkout -- dist/vendor.js` — rather than committing it.
+
+Minification does not cost you the backtrace: with `node --enable-source-maps` a failure still
+resolves to the original `src/**.ts` line. Without the flag a minified frame is only a column
+offset, so always pass it when reading a stack.
+
+Also confirm the static gate is clean before committing:
+
+```bash
+npm run prune
+```
+
+## 2. Stage
+
+Stage both `src/` and `dist/`. Review `git status` and leave unrelated files alone — do not sweep
+up scratch files or `log/` artefacts.
+
+## 3. Single commit per PR
+
+```bash
+git rev-list --count upstream/main..HEAD
+```
+
+- Count is `0` → `git commit`
+- Count is `1` or more → `git commit --amend`
+
+Never add a second commit to a branch. Write the message in the style of the existing history:
+a short imperative subject line describing the behaviour ("Adapt hostname setup tests to new
+System section UI"). **No `Co-Authored-By` trailer.**
+
+## 4. Push
+
+Confirm with the user before this step — pushing and opening a PR are outward-facing and hard to
+walk back.
+
+```bash
+git push --force-with-lease origin <branch>
+```
+
+Amending rewrites history, so a force push is required. Use `--force-with-lease`, never a bare
+`--force`.
+
+## 5. Open or update the PR
+
+```bash
+gh pr view --json url 2>/dev/null \
+  || gh pr create --repo qe-installation-and-migration/agama-integration-test-webpack --base main
+```
+
+If a PR already exists the push in step 4 has already updated it — just print the URL. Base the
+PR on `upstream` (`qe-installation-and-migration`), from your `origin` fork branch.
+
+Report the PR URL back to the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,133 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Puppeteer-based integration tests for [Agama](https://github.com/agama-project/agama) (the SUSE
+installer), bundled by Webpack into self-contained executables. The point of the bundling is that
+the Live ISO does not need Puppeteer or any Node dependency installed — only `dist/vendor.js` plus
+the test bundle are copied to the target machine (see `Rakefile`, which installs them into
+`/usr/share/agama/system-tests`).
+
+Tests use the **Node.js built-in test runner** (`node:test`), not Mocha/Jest — external runners
+cannot be bundled by Webpack.
+
+## Commands
+
+```bash
+npm ci                  # install (use ci, lockfile is committed)
+npm run build           # production build -- use this one to refresh the tracked dist/
+npm run devel           # unoptimized build, handy while iterating
+npm run watch           # dev-mode rebuild on change
+npm run eslint          # lint src/ (also runs inside webpack unless ESLINT=0)
+npm run eslint:fix
+npm run prune           # ts-prune --error: fails on unused exports (CI gate)
+```
+
+ESLint runs as a Webpack plugin with `failOnWarning: true`, so a lint warning breaks the build.
+Disable with `ESLINT=0 npm run watch` during iteration.
+
+`dist/` is tracked, so refresh it with `npm run build` before committing. Both modes run the same
+typecheck and lint; production additionally minifies every bundle and emits
+`dist/vendor.js.LICENSE.txt`, so expect a `dist/` diff wider than the files your change touched.
+Stack traces still resolve to the original `.ts` line — the source maps survive minification, but
+only with `node --enable-source-maps` (the hashbang does not set it).
+
+`npm run prune` is enforced in CI. Exports that are only reached dynamically need a
+`// ts-prune-ignore-next` comment above them.
+
+### Running a test
+
+Each `src/test_*.ts` becomes an executable `dist/test_*.js` (hashbang + chmod 755 added by
+Webpack). There is no "run all tests" command — you run one bundle at a time:
+
+```bash
+./dist/test_default_installation.js --help
+./dist/test_default_installation.js -u https://agama.local -b chrome -h -d 200 \
+  --product-version 16.1 --agama-web-ui-package-version 21+155 --product-id SLES
+node --enable-source-maps --test-reporter=tap ./dist/test_default_installation.js
+```
+
+Useful flags: `-h` headed, `-d <ms>` slow-mo, `-c` continue after failure (default aborts the rest
+of the suite), `-b firefox|chrome|chromium`. Browser paths are hardcoded in
+`browserSettings()` in `src/lib/helpers.ts`.
+
+`DEBUG_AGAMA=1` enables `debugLog()` output.
+
+On failure the wrapped `it()` dumps a screenshot, the page HTML, and `index.css` into `log/`.
+
+## Architecture
+
+Four layers, and changes usually touch several of them:
+
+```
+src/test_*.ts    entry points — parse CLI options, pick a strategy, sequence checks
+src/variants/    release strategies — map the generic API onto version-specific checks
+src/checks/      test steps — declare it() blocks and assertions
+src/pages/       page objects — Puppeteer locators and interactions
+src/lib/         helpers, CLI parsing, strategy factory, table utilities
+```
+
+**Entry points** are top-level scripts, not test suites: they call `test_init(options)` (registers
+`before`/`after` browser lifecycle hooks) and then call check functions, which register `it()`
+blocks with the Node runner. Everything is synchronous registration; the runner executes later.
+Webpack auto-discovers every `src/test_*.ts` as an entry — adding a file is all that's needed.
+
+**The strategy layer is the core abstraction.** Agama's web UI changes between releases, so the
+same logical step ("create the first user") has different flows per version.
+`ProductStrategyFactory.create(productVersion, agamaWebUiPackageVersion)` selects:
+
+- `MaintenanceReleaseStrategy` — product version `16.0` (older sidebar-based UI)
+- `DevelopmentReleaseStrategy` — `16.1` with web UI `>= 21+155`
+- `ProductionReleaseStrategy` — `16.1` otherwise; the development strategy extends it and overrides
+  only the steps that diverge
+
+All three implement `IProductTestStrategy` (defined in `src/lib/product_strategy_factory.ts`).
+Tests must go through the strategy, never call a version-specific check directly. When the UI
+changes for a new release, add the new check function and override the method in the appropriate
+strategy rather than branching inside a check.
+
+**Naming convention:** the `*WithSidebar` suffix on checks and pages (e.g.
+`enterProductRegistrationWithSidebar`, `OverviewWithSidebarPage`) marks the 16.0 sidebar UI variant.
+`MaintenanceReleaseStrategy` is where they are wired up.
+
+**Page objects** expose locators as arrow-function properties (`private readonly fooButton = () =>
+this.page.locator(...)`) so they are evaluated lazily. Optional UI capabilities are composed with
+TypeScript mixins over a `GConstructor` base — see `LicenseAcceptable` / `ModeSelectable` in
+`src/pages/product_selection_page.ts`.
+
+**Always identify elements by ARIA name *and* role.** Use Puppeteer's `::-p-aria()`
+pseudo-selector with both attributes, not the name alone:
+
+```ts
+private readonly installButton = () =>
+  this.page.locator('::-p-aria([name="Install"][role="button"])');
+```
+
+The role is what disambiguates — the same accessible name routinely appears on a heading, a link
+and a button on the same screen, and a name-only locator will match whichever comes first in the
+tree. Use the explicit `role` attribute when the markup has one, otherwise the implicit role of
+the tag (`button` → `button`, `a[href]` → `link`, `input[type=text]` → `textbox`, `select` →
+`combobox`, `input[type=checkbox]` → `checkbox`, `h1`–`h6` → `heading`).
+
+Fall back to `[aria-label='...']`, `::-p-text()`, or CSS/id selectors only when no accessible name
+is exposed. ARIA locators are stable across the UI restyling that repeatedly breaks the other
+kinds.
+
+**Checks** are the only place that registers `it()` and asserts (`node:assert/strict`). Use the
+`it()` re-exported from `src/lib/helpers.ts`, not the one from `node:test` — the wrapper adds the
+failure dumps and the abort-on-first-failure behavior. Default per-test timeout is 60s; pass a
+third argument for slow steps.
+
+Shared helpers worth knowing before writing new code: `getTextContent`, `getValue`,
+`waitUntilOverlaySettled` (wraps an action and waits for the Agama overlay to clear),
+`waitOnFile`, `sleep`, and the table readers in `src/lib/table.ts`.
+
+## Conventions
+
+- 2-space indent, double quotes, `printWidth: 100` (Prettier runs through ESLint).
+- CLI options are defined per test via the `parse((cmd) => ...)` callback in
+  `src/lib/cmdline.ts`; the base options (`--url`, `--password`, `--product-version`,
+  `--agama-web-ui-package-version`, browser flags) are shared.
+- Commits: no `Co-Authored-By` trailers.


### PR DESCRIPTION
Documentation only — no `src/` or `dist/` changes.

Adds `CLAUDE.md` documenting the four-layer architecture (`test_*` entry points → `variants/` →
`checks/` → `pages/`), the `ProductStrategyFactory` abstraction and which strategy maps to which
release, the ARIA name+role locator convention, and the build/lint/prune commands.

Also adds two skills under `.claude/skills/`:

- `agama-test` — writing or adapting a test, check or page object: classify the change, discover
  real selectors against a live instance, write to the repo conventions, pass the static gate,
  then validate with a live run.
- `ship-pr` — rebuild `dist/`, squash to one commit, push, open the PR.

The `agama-test` guidance targets Firefox over WebDriver BiDi only, since that is what the Live
ISO and openQA run, and defers to `CLAUDE.md` for the conventions it already states rather than
restating them.

## Rebuild with `npm run build`

All three documents specify `npm run build` for refreshing the tracked `dist/`, rather than
`npm run devel`. The bundles currently in git are `devel` output, so the first change that ships
under this rule will rewrite all of `dist/` and add `dist/vendor.js.LICENSE.txt` — a one-off churn
that `ship-pr` calls out so it is not mistaken for a mistake.

Minification does not cost the backtrace. Verified by running a deliberately failing test against
a live instance from both builds:

| Build | `--enable-source-maps` | Frame for the failing assertion |
|---|---|---|
| `devel` | no | `dist/test_probe.js:83:26` |
| `devel` | yes | `webpack:///src/checks/probe.ts:8:12` |
| `build` | no | `dist/test_probe.js:2:5776` |
| `build` | yes | `webpack:///src/checks/probe.ts:8:12` |

The source maps survive Terser, so a minified bundle still resolves to the original `.ts` line —
but only with the flag, since the hashbang webpack injects is a plain `#! /usr/bin/env node`.
`CLAUDE.md` and `ship-pr` both note this.

The appearance check that was originally part of this PR now lives in #293.
