### PR TITLE
Improve selector discovery script and test conventions

### DIFF
--- a/.claude/skills/discovering-selectors/SKILL.md
+++ b/.claude/skills/discovering-selectors/SKILL.md
@@ -16,16 +16,23 @@ Dump the candidates with `scripts/inspect.mjs`, run from the repo root:
 node .claude/skills/discovering-selectors/scripts/inspect.mjs
 ```
 
-Add the steps that reach the screen under test at the marked line before running it, and adjust
-the URL and password there if they are not `https://agama.local` / `nots3cr3t`.
+Adjust the constants at the top, then add the steps reaching the screen under test at the marked
+line. The script logs in and selects a product first: screens hold no meaningful state before that.
 
 It reads the DOM because `page.accessibility.snapshot()`, `createCDPSession()` and `client()` are
 unavailable under WebDriver BiDi.
 
-Capture name *and* role, then prove each candidate resolves before using it:
+Keep the added steps re-runnable — the instance keeps its state, so a second run starts where the
+first stopped. Failing on a step the previous run performed is stale state, not a wrong selector.
+
+Capture name *and* role with `dump()`, then prove each candidate with `prove()` before using it:
 
 ```js
-await page.locator('::-p-aria([name="Install"][role="button"])').wait();
+await prove("install", '::-p-aria([name="Install"][role="button"])');
 ```
+
+When two elements share name *and* role — a modal's `X` and footer both named `Close` — ARIA takes
+whichever comes first. Fall back to class plus text (`button.pf-m-primary::-p-text(Close)`), prove
+it, and say which one it targets.
 
 Report the proven locators back to the caller.

--- a/.claude/skills/discovering-selectors/scripts/inspect.mjs
+++ b/.claude/skills/discovering-selectors/scripts/inspect.mjs
@@ -2,6 +2,12 @@
 // node .claude/skills/discovering-selectors/scripts/inspect.mjs
 import * as puppeteer from "puppeteer-core";
 
+// ---- adjust per instance -----------------------------------------------
+const URL = "https://agama.local";
+const PASSWORD = "nots3cr3t";
+const PRODUCT = { id: "SLES", mode: "Standard", license: true };
+// ------------------------------------------------------------------------
+
 const browser = await puppeteer.launch({
   protocol: "webDriverBiDi",
   browser: "firefox",
@@ -11,12 +17,11 @@ const browser = await puppeteer.launch({
   defaultViewport: { width: 1280, height: 800 },
 });
 const page = await browser.newPage();
-await page.goto("https://agama.local", { waitUntil: "domcontentloaded" });
-await page.locator("input#password").fill("nots3cr3t");
-await page.locator("button[type='submit']").click();
-// ...navigate to the screen under test, then dump candidates:
-console.log(
-  await page.evaluate(() =>
+
+/** Print every visible element that could carry an accessible name, one per line. */
+const dump = async (label) => {
+  console.log(`\n===== ${label} =====`);
+  const rows = await page.evaluate(() =>
     [...document.querySelectorAll("a, button, input, select, textarea, [role], [aria-label]")]
       .filter((el) => el.getClientRects().length)
       .map((el) => ({
@@ -26,6 +31,61 @@ console.log(
         text: (el.innerText || "").replace(/\s+/g, " ").trim().slice(0, 80),
         id: el.id,
       })),
-  ),
-);
+  );
+  for (const r of rows)
+    console.log(
+      `${r.tag.padEnd(8)} role=${String(r.role).padEnd(11)} aria=${String(r.ariaLabel).padEnd(26)} id=${String(r.id).padEnd(12)} text="${r.text}"`,
+    );
+};
+
+/** Prove a candidate resolves before writing it into a page object. */
+const prove = async (label, selector) => {
+  try {
+    await page.locator(selector).setTimeout(5000).wait();
+    console.log(`OK   ${label}: ${selector}`);
+  } catch {
+    console.log(`FAIL ${label}: ${selector}`);
+  }
+};
+
+const logIn = async () => {
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.locator("input#password").fill(PASSWORD);
+  await page.locator("button[type='submit']").click();
+};
+
+const waitForOverview = () =>
+  page
+    .locator('::-p-aria([name="System Information"][role="heading"])')
+    .setTimeout(180 * 1000)
+    .wait();
+
+/**
+ * Most screens only hold meaningful state once a product is selected. Idempotent: an instance
+ * that already has a product selected lands on the overview, so this is a no-op there.
+ */
+const selectProduct = async ({ id, mode, license }) => {
+  const selectButton = await page.$("button[form='productSelectionForm']");
+  if (!selectButton) {
+    console.log("product already selected, skipping product selection");
+    return waitForOverview();
+  }
+  await page.locator(`input#${id.replaceAll(".", "\\.")}`).click();
+  if (mode) await page.locator(`::-p-aria([name="${mode}"])`).click();
+  if (license) {
+    const accepted = await page.evaluate(
+      () => document.querySelector("input[type='checkbox']")?.checked === true,
+    );
+    if (!accepted) await page.locator("::-p-text(I have read and)").click();
+  }
+  await page.locator("button[form='productSelectionForm']").click();
+  return waitForOverview();
+};
+
+await logIn();
+await selectProduct(PRODUCT);
+
+// ...navigate to the screen under test, then dump candidates and prove the ones you picked:
+await dump("SCREEN UNDER TEST");
+
 await browser.close();

--- a/.claude/skills/following-test-conventions/SKILL.md
+++ b/.claude/skills/following-test-conventions/SKILL.md
@@ -25,9 +25,18 @@ Selectors follow CLAUDE.md's ARIA name-and-role convention and its fallback orde
 engine-neutral: `::-webkit-*` and other vendor-prefixed pseudo-elements silently fail in Firefox,
 while Puppeteer's `::-p-text()` / `::-p-aria()` are fine.
 
-Page objects, checks, helpers, `*WithSidebar` naming and ts-prune follow CLAUDE.md. Two additions:
+Page objects, checks, helpers, `*WithSidebar` naming and ts-prune follow CLAUDE.md, plus:
 
 - Copy the shape of `src/pages/system_page.ts` with `setStaticHostname` in `src/checks/system.ts`:
   one named ARIA locator per element, one action method per interaction, a check that reads top to
   bottom.
+- **Name a page object after the main heading it drives**, not the action opening it:
+  `InstallationSettingsInJsonFormatPage`. The check keeps the step name (`showConfiguration`).
+- **Declare the page objects first** in the `it()` body, named after the class without the `Page`
+  suffix: `new InstallationSettingsInJsonFormatPage(page)` → `installationSettingsInJsonFormat`.
+- **Keep the default `it()` timeout** unless the step really runs long, like an installation.
+- **No redundant waits** — every locator already waits.
+- **Page objects import nothing from `src/lib/`.** Read through a getter built on the locator's own
+  `.map().wait()`, as `AppearancePage` does; expose a `public readonly` locator only when the check
+  must wait on the element itself. Selector-less reads such as the clipboard are helpers.
 - **Reuse before adding** — read `src/lib/helpers.ts` and `src/lib/table.ts` first.


### PR DESCRIPTION
Splits the Claude Code skill changes out of the show-configuration work so they can be reviewed on their own.

## `discovering-selectors`

- The `inspect.mjs` script now logs in and selects a product before dumping, since most screens hold no meaningful state before that. Product selection is idempotent, so an instance that already has one selected just lands on the overview.
- Instance settings (URL, password, product) moved to constants at the top instead of being edited inline.
- Added `dump(label)`, which prints one readable line per candidate element instead of a raw object array, and `prove(label, selector)`, which reports OK/FAIL for a candidate against a 5s timeout.
- Documented that the added navigation steps must be re-runnable — the instance keeps state between runs, so a failure on an already-performed step is stale state, not a bad selector.
- Documented the name+role collision case (a modal's `X` and its footer button both named `Close`) and the class-plus-text fallback.

## `following-test-conventions`

New rules, all drawn from writing the show-configuration check:

- Name a page object after the main heading it drives, not the action that opens it.
- Name the page object variable after the class without the `Page` suffix.
- Keep the default `it()` timeout unless the step genuinely runs long.
- No redundant waits — every locator already waits.
- Page objects import nothing from `src/lib/`; read through a getter built on the locator's own `.map().wait()`.

No source or `dist/` changes.