### PR TITLE
Updated CI tag naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           # for a fork PR is the fork itself: owner/fork-name
           repository: ${{ github.repository }}
-          tag_name: ${{ github.ref_name }}
+          tag_name: tag-${{ github.ref_name }}
           name: "Build of branch ${{ github.ref_name }}"
           files: ${{ github.sha }}.tar.gz


### PR DESCRIPTION
We have changed the tag naming of CI release process.
When we push and tag + branch are named the same git is not able to resolve where to push automatically, this solves the issue.

- Related ticket: https://progress.opensuse.org/issues/189948
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26537
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/24132705#