### PR TITLE
Selector Migration to ARIA with Roles - Group 1

### DIFF
--- a/src/checks/authentication.ts
+++ b/src/checks/authentication.ts
@@ -89,7 +89,7 @@ export function verifyPasswordStrength() {
     await setARootPassword.selectPasswordAsRootLoginMethod();
     await setARootPassword.fillRootPassword("a23b56c");
     const elementTextPasswordLess8Characters = await getTextContent(
-      setARootPassword.alertPasswordLess8Characters(),
+      setARootPassword.alertPasswordLess8CharactersHeading(),
     );
     assert.deepEqual(
       elementTextPasswordLess8Characters,
@@ -97,12 +97,14 @@ export function verifyPasswordStrength() {
     );
 
     await setARootPassword.fillPassword("a23b56ca");
-    const elementTextPasswordIsWeak = await getTextContent(setARootPassword.alertPasswordIsWeak());
+    const elementTextPasswordIsWeak = await getTextContent(
+      setARootPassword.alertPasswordIsWeakHeading(),
+    );
     assert.deepEqual(elementTextPasswordIsWeak, "The password is weak");
 
     await setARootPassword.fillPassword("a23b5678");
     const elementTextPasswordFailDictionary = await getTextContent(
-      setARootPassword.alertPasswordFailDictionaryCheck(),
+      setARootPassword.alertPasswordFailDictionaryCheckHeading(),
     );
     assert.deepEqual(
       elementTextPasswordFailDictionary,
@@ -123,7 +125,7 @@ export function verifyPasswordStrengthWithSidebar() {
 
     await setARootPassword.fillPassword("a23b56c");
     const elementTextPasswordLess8Characters = await getTextContent(
-      setARootPassword.alertPasswordLess8Characters(),
+      setARootPassword.alertPasswordLess8CharactersHeading(),
     );
     assert.deepEqual(
       elementTextPasswordLess8Characters,
@@ -131,12 +133,14 @@ export function verifyPasswordStrengthWithSidebar() {
     );
 
     await setARootPassword.fillPassword("a23b56ca");
-    const elementTextPasswordIsWeak = await getTextContent(setARootPassword.alertPasswordIsWeak());
+    const elementTextPasswordIsWeak = await getTextContent(
+      setARootPassword.alertPasswordIsWeakHeading(),
+    );
     assert.deepEqual(elementTextPasswordIsWeak, "Warning alert:The password is weak");
 
     await setARootPassword.fillPassword("a23b5678");
     const elementTextPasswordFailDictionary = await getTextContent(
-      setARootPassword.alertPasswordFailDictionaryCheck(),
+      setARootPassword.alertPasswordFailDictionaryCheckHeading(),
       50000,
     );
     assert.deepEqual(

--- a/src/checks/login.ts
+++ b/src/checks/login.ts
@@ -27,7 +27,7 @@ export function logInWithIncorrectPassword() {
     await loginAsRoot.fillPassword(invalidpassword);
     await loginAsRoot.logIn();
     assert.deepEqual(
-      await getTextContent(loginAsRoot.couldNotLoginText()),
+      await getTextContent(loginAsRoot.couldNotLoginHeading()),
       "Danger alert:Could not log in",
     );
     await loginAsRoot.togglePasswordVisibility();
@@ -43,7 +43,7 @@ export function logInWithIncorrectPasswordWithSidebar() {
 
     await loginAsRoot.fillPassword(invalidpassword);
     await loginAsRoot.logIn();
-    const alertText = await getTextContent(loginAsRoot.couldNotLoginText());
+    const alertText = await getTextContent(loginAsRoot.couldNotLoginHeading());
     assert.deepEqual(
       alertText,
       "Danger alert:Could not log in. Please, make sure that the password is correct.",

--- a/src/pages/authentication_page.ts
+++ b/src/pages/authentication_page.ts
@@ -16,18 +16,22 @@ class AuthenticationAdministratorAccountPage {
   private readonly usernameCombobox = () =>
     this.page.locator("::-p-aria(Username[role='combobox'])");
 
-  private readonly userPasswordInput = () => this.page.locator("input#userPassword");
+  private readonly userPasswordInput = () =>
+    this.page.locator("input::-p-aria(Administrator account Password)");
+
   private readonly userPasswordConfirmationInput = () =>
-    this.page.locator("input#userPasswordConfirmation");
+    this.page.locator("input::-p-aria(Administrator account Password confirmation)");
 
   protected readonly acceptButton = () => this.page.locator("::-p-aria(Accept[role='button'])");
 
-  public readonly alertPasswordLess8Characters = () =>
-    this.page.locator("::-p-text(The password is shorter than 8 characters)");
+  public readonly alertPasswordLess8CharactersHeading = () =>
+    this.page.locator("::-p-aria(The password is shorter than 8 characters)");
 
-  public readonly alertPasswordIsWeak = () => this.page.locator("::-p-text(The password is weak)");
-  public readonly alertPasswordFailDictionaryCheck = () =>
-    this.page.locator("::-p-text(it is too simplistic/systematic)");
+  public readonly alertPasswordIsWeakHeading = () =>
+    this.page.locator("::-p-aria(The password is weak)");
+
+  public readonly alertPasswordFailDictionaryCheckHeading = () =>
+    this.page.locator("::-p-aria(it is too simplistic/systematic)");
 
   constructor(page: Page) {
     this.page = page;
@@ -69,10 +73,11 @@ function RootLoginMethodPasswordDefinable<
     private readonly rootPasswordOption = () =>
       this.page.locator("::-p-aria(Password Log in using a password[role='option'])");
 
-    private readonly rootPasswordInput = () => this.page.locator("input#rootPassword");
+    private readonly rootPasswordInput = () =>
+      this.page.locator("input::-p-aria(Root account Password)");
 
     private readonly rootPasswordConfirmationInput = () =>
-      this.page.locator("input#rootPasswordConfirmation");
+      this.page.locator("input::-p-aria(Root account Password confirmation)");
 
     async selectPasswordAsRootLoginMethod() {
       await this.rootPasswordOption().click();

--- a/src/pages/create_user_page.ts
+++ b/src/pages/create_user_page.ts
@@ -2,24 +2,27 @@ import { type Page } from "puppeteer-core";
 
 export class CreateFirstUserPage {
   private readonly page: Page;
-  private readonly fullNameInput = () => this.page.locator("input#userFullName");
-  private readonly usernameInput = () => this.page.locator("input#userName");
-  private readonly passwordInput = () => this.page.locator("input#password");
-  private readonly passwordConfirmationInput = () =>
-    this.page.locator("input#passwordConfirmation");
+  private readonly fullNameTextbox = () =>
+    this.page.locator("::-p-aria(Full name[role='textbox'])");
 
-  private readonly acceptButton = () => this.page.locator("button[form='firstUserForm']");
+  private readonly usernameTextbox = () => this.page.locator("::-p-aria(Username[role='textbox'])");
+  private readonly passwordInput = () => this.page.locator("input::-p-aria(Password)");
+
+  private readonly passwordConfirmationInput = () =>
+    this.page.locator("input::-p-aria(Password confirmation)");
+
+  private readonly acceptButton = () => this.page.locator("::-p-aria(Accept[role='button'])");
 
   constructor(page: Page) {
     this.page = page;
   }
 
   async fillFullName(fullName: string) {
-    await this.fullNameInput().fill(fullName);
+    await this.fullNameTextbox().fill(fullName);
   }
 
   async fillUserName(userName: string) {
-    await this.usernameInput().fill(userName);
+    await this.usernameTextbox().fill(userName);
   }
 
   async fillPassword(password: string) {

--- a/src/pages/login_as_root_page.ts
+++ b/src/pages/login_as_root_page.ts
@@ -2,12 +2,14 @@ import { type Page } from "puppeteer-core";
 
 export class LoginAsRootPage {
   private readonly page: Page;
-  readonly passwordInput = () => this.page.locator("input#password");
-  private readonly logInButton = () => this.page.locator("button[type='submit']");
-  readonly couldNotLoginText = () => this.page.locator(`::-p-text(Could not log in)`);
+  readonly passwordInput = () => this.page.locator("::-p-aria(Password input)");
+
+  private readonly logInButton = () => this.page.locator("::-p-aria(Log in[role='button'])");
+  readonly couldNotLoginHeading = () =>
+    this.page.locator("::-p-aria(Danger alert: Could not log in[role='heading'])");
 
   readonly passwordVisibilityButton = () =>
-    this.page.locator("[aria-label='Password visibility button']");
+    this.page.locator("::-p-aria(Password visibility button[role='button'])");
 
   constructor(page: Page) {
     this.page = page;

--- a/src/pages/root_authentication_methods.ts
+++ b/src/pages/root_authentication_methods.ts
@@ -2,31 +2,33 @@ import { type Page } from "puppeteer-core";
 
 export class SetARootPasswordPage {
   private readonly page: Page;
-  private readonly acceptText = () => this.page.locator("button::-p-text(Accept)");
-  private readonly confirmText = () => this.page.locator("button::-p-text(Confirm)");
-  private readonly passwordInput = () => this.page.locator("input#password");
+  private readonly acceptButton = () => this.page.locator("::-p-aria(Accept[role='button'])");
+  private readonly passwordInput = () => this.page.locator("input::-p-aria(Password)");
   private readonly passwordConfirmationInput = () =>
-    this.page.locator("input#passwordConfirmation");
+    this.page.locator("input::-p-aria(Password confirmation)");
 
-  public readonly alertPasswordLess8Characters = () =>
-    this.page.locator("::-p-text(The password is shorter than 8 characters)");
+  public readonly alertPasswordLess8CharactersHeading = () =>
+    this.page.locator(
+      "::-p-aria(Warning alert: The password is shorter than 8 characters[role='heading'])",
+    );
 
-  public readonly alertPasswordIsWeak = () => this.page.locator("::-p-text(The password is weak)");
-  public readonly alertPasswordFailDictionaryCheck = () =>
-    this.page.locator("::-p-text(it is too simplistic/systematic)");
+  public readonly alertPasswordIsWeakHeading = () =>
+    this.page.locator("::-p-aria(Warning alert: The password is weak[role='heading'])");
 
-  private readonly usePasswordToggle = () => this.page.locator("::-p-text(Use password)");
+  public readonly alertPasswordFailDictionaryCheckHeading = () =>
+    this.page.locator(
+      "::-p-aria(Warning alert: The password fails the dictionary check - it is too simplistic/systematic[role='heading'])",
+    );
+
+  private readonly usePasswordCheckbox = () =>
+    this.page.locator("::-p-aria(Use password[role='checkbox'])");
 
   constructor(page: Page) {
     this.page = page;
   }
 
   async accept() {
-    await this.acceptText().click();
-  }
-
-  async confirm() {
-    await this.confirmText().click();
+    await this.acceptButton().click();
   }
 
   async fillPassword(password: string) {
@@ -38,6 +40,6 @@ export class SetARootPasswordPage {
   }
 
   async usePassword() {
-    await this.usePasswordToggle().click();
+    await this.usePasswordCheckbox().click();
   }
 }


### PR DESCRIPTION
We have migrated the locators to ARIA, we left input fields because they cannot contain role and it is not working as AI suggest.

- Related ticket: https://jira.suse.com/browse/QEIM-24
- Verification run: 
  - maintenance: https://openqa.suse.de/tests/24133706#
  - production: https://openqa.suse.de/tests/24133705#