### PR TITLE
Changed release strategy to overwrite release files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: Create archive
         if: github.event_name == 'push'
-        run: tar -czf ${{ github.sha }}.tar.gz dist
+        run: |
+          echo "${{ github.sha }}" > dist/BUILD_SHA
+          tar -czf agama-integration-tests.tar.gz dist
 
       - name: Release on push to branch
         if: github.event_name == 'push'
@@ -48,6 +50,7 @@ jobs:
         with:
           # for a fork PR is the fork itself: owner/fork-name
           repository: ${{ github.repository }}
-          tag_name: ${{ github.ref_name }}
+          tag_name: tag-${{ github.ref_name }}
           name: "Build of branch ${{ github.ref_name }}"
-          files: ${{ github.sha }}.tar.gz
+          files: agama-integration-tests.tar.gz
+          overwrite_files: true


### PR DESCRIPTION
We have changed the way to release the files instead of using commits We added the SHA inside the compiled files
Then we overwrite the last uploaded compilation

- Related ticket: https://progress.opensuse.org/issues/189948
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26554
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/24152270#