### PR TITLE
Fix verifySoftwareSelectionNotAvailable not present in QU0

### DIFF
--- a/src/test_extended.ts
+++ b/src/test_extended.ts
@@ -44,7 +44,7 @@ if (options.productId !== "none")
     productSelectionWithLicenseAndMode(options.productId, options.productMode);
   else productSelection(options.productId);
 testStrategy.ensureLandingOnOverview();
-testStrategy.verifySoftwareSelectionNotAvailable();
+testStrategy.verifySoftwareSelectionNotAvailable?.();
 testStrategy.verifyAppearanceChanges?.();
 if (options.staticHostname) testStrategy.setStaticHostname(options.staticHostname);
 if (options.ntpServerAddresses)


### PR DESCRIPTION
We have added a small code to allow this method to be called in case QU0 reach that point on sles_extended.

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26571