### PR TITLE
Fix locators for root password warning

### DIFF
--- a/src/pages/authentication_page.ts
+++ b/src/pages/authentication_page.ts
@@ -25,13 +25,15 @@ class AuthenticationAdministratorAccountPage {
   protected readonly acceptButton = () => this.page.locator("::-p-aria(Accept[role='button'])");
 
   public readonly alertPasswordLess8CharactersHeading = () =>
-    this.page.locator("::-p-aria(The password is shorter than 8 characters)");
+    this.page.locator(
+      "div[aria-live='polite'] ::-p-text(The password is shorter than 8 characters)",
+    );
 
   public readonly alertPasswordIsWeakHeading = () =>
-    this.page.locator("::-p-aria(The password is weak)");
+    this.page.locator("div[aria-live='polite'] ::-p-text(The password is weak)");
 
   public readonly alertPasswordFailDictionaryCheckHeading = () =>
-    this.page.locator("::-p-aria(it is too simplistic/systematic)");
+    this.page.locator("div[aria-live='polite'] ::-p-text(it is too simplistic/systematic)");
 
   constructor(page: Page) {
     this.page = page;


### PR DESCRIPTION
##
### Fix locators for root password warning
- Failed job: 
  - [sles_notifications](https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&test=sles_notifications&distri=sle&version=16.1&build=66.1&groupid=612)
- Related ticket: Quick PR
- VR:
  - [sles_notifications_dev](https://openqa.suse.de/tests/overview?version=16.1&build=hjluo_sles_notifications_888&distri=sle)

##