### PR TITLE
Fix s390x zVM lvm test with DASD device

### DIFF
--- a/src/checks/storage_dasd.ts
+++ b/src/checks/storage_dasd.ts
@@ -21,9 +21,6 @@ export function prepareDasdStorage() {
       await dasd.selectDeviceToFormat();
       page.setDefaultTimeout(6 * 60 * 1000);
       await waitUntilOverlaySettled(() => dasd.formatNowDevice());
-
-      await header.goToStorage();
-      await storage.waitForElement("::-p-text(Installation devices)", 60000);
       await header.goToInstallation();
     },
     7 * 60 * 1000,


### PR DESCRIPTION
##
### Fix s390x zVM lvm test with DASD device

This is a workaround to fix [bug#1279602](https://bugzilla.suse.com/show_bug.cgi?id=1279602) that we can't click Storage in header after DASD configure finished.

- Related ticket: Quick PR
- Related failed job:
  - https://openqa.suse.de/tests/24252051#step/agama/14
- VR:
  - https://openqa.suse.de/tests/24293997
##